### PR TITLE
formatting issue with next

### DIFF
--- a/chapter03_deep-neural-networks/mlp-dropout-gluon.ipynb
+++ b/chapter03_deep-neural-networks/mlp-dropout-gluon.ipynb
@@ -406,7 +406,7 @@
    "metadata": {},
    "source": [
     "## Next\n",
-    "[Introduction to ``gluon.Block`` and ``gluon.nn.Sequential``](../chapter03_deep-neural-networks/plumbing.ipynb)"
+    "[Introduction to gluon.Block and gluon.nn.Sequential](../chapter03_deep-neural-networks/plumbing.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
There is likely a better fix than this edit, but currently the next statements for going to the next tutuorial section at the bottom of the page are not correctly rendered for ''gluon.Block'' on these
two pages:
http://gluon.mxnet.io/chapter03_deep-neural-networks/mlp-dropout-gluon.html
http://gluon.mxnet.io/chapter03_deep-neural-networks/plumbing.html

Screen shot of what the error looks like on firefox, same on safari

![screenshot-2017-12-8 plumbing a look under the hood of gluon the straight dope 0 1 documentation](https://user-images.githubusercontent.com/22106627/33769083-996f6b5c-dbdd-11e7-804a-3fb0997dfefe.png)
